### PR TITLE
Start to Build Simple Packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
 cmake_policy(VERSION 3.15...3.20)
 
-project(FairCMakeModules VERSION 0.1.0 LANGUAGES CXX)
+project(FairCMakeModules VERSION 0.1.0 LANGUAGES CXX
+        HOMEPAGE_URL "https://github.com/FairRootGroup/FairCMakeModules")
 message(STATUS "${PROJECT_NAME} Version ${PROJECT_VERSION}")
 
 include(GNUInstallDirs)
@@ -50,3 +51,18 @@ install(
     README.md
     CHANGELOG.md
   DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+
+
+set(CPACK_GENERATOR "DEB")
+set(CPACK_VERBATIM_VARIABLES TRUE)
+set(CPACK_PACKAGE_CONTACT "FairSoft <fairsoft-at-gsi@example.org>")
+set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
+set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "all")
+set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CMAKE_PROJECT_HOMEPAGE_URL}")
+set(CPACK_SOURCE_GENERATOR "TXZ")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "${PROJECT_NAME}-${PROJECT_VERSION}")
+set(CPACK_SOURCE_IGNORE_FILES
+  \\.git/
+  build/
+  ".*~$")
+include(CPack)


### PR DESCRIPTION
CMake can create Packages using CPack. It has two modes of operation:

Binary Packages
===============

It creates binary packages directly from information given in CMakeLists.txt. For example it can create Debian packages (more on that below). Those packages follow the rules of that binary package format quite closely. It mostly builds the "binaries" in a normal way and then packages them up.

Here I tried to setup Debian packages. As the building of the package is done directly by CMake/CPack with only little help by the standard Debian packaging toolchain, there are some shortcomings:
* There is no "Debian Source Package". The binary package just is delivered at the end.
  * This is not usable at all for uploading to a mainstream Debian archive!
* All the Debian metadata has to be configured in CMake, which doesn't feel at all like "Debian"
* One has to inspect the resulting binary package and make sure it conforms to all requirements (for example Packaging Guidelines by Debian).

This initial version of the Debian package gets most of the basic stuff right, but there are things missing.
* DOCDIR should be with a lowercase project name
* Some metadata is missing from the package

Source Package
==============

This can be used to create "release tarballs".

It really just tars up the source tree and ignores some files as specified in CMake configuration. The final tarball name and some things can also be controlled by CMake. This could be used to prepare some things in the source tree and then do a release.

This is really the absolute minimum to get this going. More meant for experimentation.