### PR TITLE
feature: Add Initial gitlint Config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 ---
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - '**'
+    - '!pr/**'
+  pull_request:
 jobs:
   main:
     strategy:

--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,20 @@
+[general]
+ignore=body-is-missing
+
+# Enable these contrib rules:
+# contrib=contrib-title-conventional-commits
+
+ignore-merge-commits=false
+ignore-revert-commits=false
+ignore-fixup-commits=false
+ignore-squash-commits=false
+
+[title-max-length]
+# https://chris.beams.io/posts/git-commit/#seven-rules
+# No. 2
+# Add 15, so that contrib-title-conventional-commits works better
+line-length=65
+
+# [contrib-title-conventional-commits]
+# types=fix,feature
+


### PR DESCRIPTION
gitlint looks like an interesting tool to check conformance of git commit messages to some rules.

This initial config allows all previous commits of this repository.

It has the conventional commits prepared but not yet enabled.