### PR TITLE
find_package2 install prefix auto-detection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,16 @@ Changelog
 *********
 .. View rendered on https://fairrootgroup.github.io/FairCMakeModules/latest/changelog.html
 
-Unreleased
-==========
+Unreleased **v1.0.0** 2021-xx-xx
+================================
 
-(empty)
+New
+---
+
+* :command:`find_package2` auto-detects the install prefix and populates the result in
+  :variable:`<pkgname>_PREFIX`. Can be disabled globally via
+  :variable:`FAIR_NO_AUTO_DETECT_PREFIX`.
+
 
 **v0.2.0 (beta)** 2021-05-24
 ============================

--- a/src/modules/FairFindPackage2.cmake.in
+++ b/src/modules/FairFindPackage2.cmake.in
@@ -39,6 +39,63 @@ if(@PROJECT_NAME@_FOUND)
   list(APPEND PROJECT_PACKAGE_DEPENDENCIES @PROJECT_NAME@)
 endif()
 
+# private helper function to find longest common prefix in given
+# true-thy strings
+function(__find_package2_lcp)
+  cmake_parse_arguments(ARGS "" "OUTVAR" "STRINGS" ${ARGN})
+
+  if(NOT ARGS_OUTVAR)
+    message(AUTHOR_WARNING "Parameter OUTVAR required. Skipping.")
+    return()
+  endif()
+
+  if(NOT ARGS_STRINGS)
+    message(AUTHOR_WARNING "Parameter list STRINGS required. Skipping.")
+    return()
+  endif()
+
+  list(LENGTH ARGS_STRINGS __list_length)
+  if(__list_length EQUAL 1)
+    set(${ARGS_OUTVAR} "${ARGS_STRINGS}" PARENT_SCOPE)
+    return()
+  endif()
+
+  set(__lcp)
+  set(__pos 0)
+
+  set(__pos_ok TRUE)
+  while(__pos_ok)
+    set(__current_char)
+    foreach(__str IN LISTS ARGS_STRINGS)
+      if(__str)
+        string(LENGTH "${__str}" __length)
+        if(__length GREATER __pos)
+          string(SUBSTRING "${__str}" ${__pos} 1 __char)
+          string(LENGTH "${__current_char}" __current_char_length)
+          if(NOT __current_char_length)
+            set(__current_char ${__char})
+          else()
+            if(NOT __current_char STREQUAL __char)
+              set(__pos_ok FALSE)
+              break()
+            endif()
+          endif()
+        else()
+          set(__pos_ok FALSE)
+          break()
+        endif()
+      endif()
+    endforeach()
+    string(LENGTH "${__current_char}" __current_char_length)
+    if(__pos_ok AND __current_char_length)
+      string(APPEND __lcp ${__current_char})
+    endif()
+    math(EXPR __pos "${__pos} + 1")
+  endwhile()
+
+  set(${ARGS_OUTVAR} "${__lcp}" PARENT_SCOPE)
+endfunction()
+
 #[=======================================================================[.rst:
 ---------
 

--- a/src/modules/FairFindPackage2.cmake.in
+++ b/src/modules/FairFindPackage2.cmake.in
@@ -134,15 +134,23 @@ The ``ADD_REQUIREMENTS_OF`` argument is now a no-op and only remains for
 compatibility reasons. :command:`find_package2` now always merges all known
 requirements.
 
+.. versionadded:: 1.0.0
+
+By default :command:`find_package2` tries to determine the install prefix if
+the package is found. The result is populated to the variable
+:variable:`<pkgname>_PREFIX``. This behaviour can be disabled by setting the
+:variable:`FAIR_NO_AUTO_DETECT_PREFIX` to ``ON``.
+
 #]=======================================================================]
 
 macro(find_package2 qualifier pkgname)
   cmake_parse_arguments(ARGS "" "VERSION"
                         "COMPONENTS;ADD_REQUIREMENTS_OF;OPTIONAL_COMPONENTS" ${ARGN})
 
-  string(TOUPPER ${pkgname} pkgname_upper)
+  string(TOUPPER ${pkgname} __pkgname_upper__)
+  string(TOLOWER ${pkgname} __pkgname_lower__)
   set(__old_cpp__ ${CMAKE_PREFIX_PATH})
-  set(CMAKE_PREFIX_PATH ${${pkgname_upper}_ROOT} $ENV{${pkgname_upper}_ROOT} ${CMAKE_PREFIX_PATH})
+  set(CMAKE_PREFIX_PATH ${${__pkgname_upper__}_ROOT} $ENV{${__pkgname_upper__}_ROOT} ${CMAKE_PREFIX_PATH})
 
   # build lists of required versions and components
   unset(__required_versions__)
@@ -188,6 +196,10 @@ macro(find_package2 qualifier pkgname)
     list(REMOVE_DUPLICATES __optional_components__)
   endif()
 
+  if(NOT FAIR_NO_AUTO_DETECT_PREFIX)
+    set(PACKAGE_PREFIX_DIR)
+  endif()
+
   # call native find_package
   if(__components__ AND __optional_components__)
     find_package(${pkgname} ${__version__} QUIET COMPONENTS ${__components__} OPTIONAL_COMPONENTS ${__optional_components__} ${ARGS_UNPARSED_ARGUMENTS})
@@ -197,6 +209,89 @@ macro(find_package2 qualifier pkgname)
     find_package(${pkgname} ${__version__} QUIET OPTIONAL_COMPONENTS ${__optional_components__} ${ARGS_UNPARSED_ARGUMENTS})
   else()
     find_package(${pkgname} ${__version__} QUIET ${ARGS_UNPARSED_ARGUMENTS})
+  endif()
+
+  if(NOT DEFINED ${pkgname}_PREFIX AND ${pkgname}_FOUND AND NOT FAIR_NO_AUTO_DETECT_PREFIX)
+    # try to detect install prefix
+    set(__candidates)
+    set(__subdir_candidates)
+    foreach(__pkg IN ITEMS ${pkgname} ${__pkgname_upper__} ${__pkgname_lower__})
+      # guess targets
+      foreach(__pkg2 IN ITEMS ${pkgname} ${__pkgname_upper__} ${__pkgname_lower__})
+        foreach(__tgt IN ITEMS
+          "${__pkg}"
+          "${__pkg}::headers"
+          "${__pkg}::${__pkg2}"
+          "${__pkg}::${__pkg2}_shared"
+          "${__pkg}::${__pkg2}_static"
+        )
+          if(TARGET ${__tgt})
+            get_target_property(__includes ${__tgt} INTERFACE_INCLUDE_DIRECTORIES)
+            if(__includes)
+              list(APPEND __subdir_candidates "${__includes}")
+            endif()
+            unset(__includes)
+            get_target_property(__location ${__tgt} INTERFACE_LOCATION)
+            if(__location)
+              list(APPEND __subdir_candidates "${__location}")
+            endif()
+            unset(__location)
+          endif()
+        endforeach()
+      endforeach()
+
+      # guess variables
+      foreach(__var IN ITEMS
+        ${${__pkg}_BIN_DIR}
+        ${${__pkg}_BINDIR}
+        ${${__pkg}_INCLUDE_DIR}
+        ${${__pkg}_INCLUDEDIR}
+        ${${__pkg}_INCLUDE_DIRS}
+        ${${__pkg}_INCLUDEDIRS}
+        ${${__pkg}_INCDIR}
+        ${${__pkg}_LIBRARY_DIR}
+        ${${__pkg}_LIBRARYDIR}
+        ${${__pkg}_LIBRARY_DIRS}
+        ${${__pkg}_LIBRARYDIRS}
+        ${${__pkg}_LIBRARY_SHARED}
+        ${${__pkg}_LIBRARY_STATIC}
+        ${${__pkg}_LIBDIR}
+        ${${__pkg}_DIR}
+      )
+        if(__var)
+          list(APPEND __subdir_candidates ${__var})
+        endif()
+      endforeach()
+      list(APPEND __candidates
+        ${${__pkg}_EXECUTABLE}
+        ${${__pkg}_PREFIX}
+        ${${__pkg}_INSTALL_PREFIX}
+        ${${__pkg}_INSTALLPREFIX}
+        ${${__pkg}_INSTALL}
+      )
+    endforeach()
+    list(APPEND __candidates ${PACKAGE_PREFIX_DIR})
+
+    foreach(__subcand IN LISTS __subdir_candidates)
+      # we assume that these paths are least one directory
+      # level below the prefix
+      if(__subcand)
+        get_filename_component(__cand ${__subcand}/.. ABSOLUTE)
+        list(APPEND __candidates "${__cand}")
+        unset(__cand)
+      endif()
+    endforeach()
+    if(__candidates)
+      list(REMOVE_DUPLICATES __candidates)
+      __find_package2_lcp(OUTVAR ${pkgname}_PREFIX STRINGS ${__candidates})
+      message(VERBOSE "Guessing '${pkgname}' install prefix from: '${__candidates}' --> '${${pkgname}_PREFIX}'")
+    endif()
+    unset(__subdir_candidates)
+    unset(__candidates)
+
+    if(${pkgname}_PREFIX AND EXISTS ${pkgname}_PREFIX)
+      set(${pkgname}_PREFIX "${${pkgname}_PREFIX}" CACHE PATH "Auto-detected install prefix of package '${pkgname}'")
+    endif()
   endif()
 
   if(${qualifier} STREQUAL BUNDLED)
@@ -232,6 +327,8 @@ macro(find_package2 qualifier pkgname)
     endif()
   endif()
 
+  unset(__pkgname_lower__)
+  unset(__pkgname_upper__)
   unset(__qualifier__)
   unset(__version__)
   unset(__components__)

--- a/tests/FairFindPackage2/CMakeLists.txt
+++ b/tests/FairFindPackage2/CMakeLists.txt
@@ -18,6 +18,7 @@ add_module_test(SUITE "find_package2" TEST "simple"
                 PREFIX_PATH ${pkgset1})
 add_module_test(SUITE "find_package2" TEST "merge_requirements"
                 PREFIX_PATH ${pkgset2})
+add_module_test(SUITE "find_package2" TEST "lcp")
 
 add_module_test(SUITE "fair_generate_package_dependencies" TEST "simple"
                 PREFIX_PATH ${pkgset1})

--- a/tests/FairFindPackage2/find_package2_lcp.cmake
+++ b/tests/FairFindPackage2/find_package2_lcp.cmake
@@ -1,0 +1,42 @@
+################################################################################
+#    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+#                                                                              #
+#              This software is distributed under the terms of the             #
+#              GNU Lesser General Public Licence (LGPL) version 3,             #
+#                  copied verbatim in the file "LICENSE"                       #
+################################################################################
+
+__find_package2_lcp(OUTVAR actual STRINGS
+  "/usr/include"
+  "/usr/share/cmake/FooBar-42"
+)
+assert_var_equal(actual "/usr/")
+
+__find_package2_lcp(OUTVAR actual STRINGS
+  "single string"
+)
+assert_var_equal(actual "single string")
+
+__find_package2_lcp(OUTVAR actual STRINGS
+  "/usr/include"
+  "/usr/share/cmake/FooBar-42"
+  "/usr/lib64"
+  "/usr/include/foobar"
+)
+assert_var_equal(actual "/usr/")
+
+__find_package2_lcp(OUTVAR actual STRINGS
+  "/usr/include"
+  ""
+  "/usr/lib64-NOTFOUND"
+  "/usr/include/foobar"
+)
+assert_var_equal(actual "/usr/include")
+
+__find_package2_lcp(OUTVAR actual STRINGS
+  "/usr/include"
+  "asdf"
+  "/usr/lib64"
+  "/usr/include/foobar"
+)
+assert_var_equal(actual "")


### PR DESCRIPTION
A proposal to migrate logic like [this](https://github.com/dennisklein/FairMQ/blob/cb2eca9c4ae7faa7cf764d82141b801e1d8299ce/cmake/FairMQDependencies.cmake#L92-L149) to FCM generically.