### PR TITLE
feature: Simplify and Document Adding new Modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ string(TOLOWER "${PROJECT_NAME}" PROJECT_NAME_LOWER)
 set(PROJECT_INSTALL_DATADIR "${CMAKE_INSTALL_DATAROOTDIR}/${PROJECT_NAME_LOWER}")
 set(PROJECT_INSTALL_MODULESDIR "${PROJECT_INSTALL_DATADIR}/modules")
 
+# Modules that are just installed and can be used straight away:
+set(simple_modules
+    FairFormattedOutput
+    FairSummary
+)
+
 add_subdirectory(src)
 add_subdirectory(tests)
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -22,3 +22,14 @@ add_custom_target(docs
   COMMENT "Generating documentation"
   VERBATIM
 )
+
+foreach(module IN LISTS simple_modules)
+  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/module/${module}.rst")
+    message(FATAL_ERROR "You must document ${module}!
+
+      Create '${CMAKE_CURRENT_SOURCE_DIR}/module/${module}.rst'
+      Recommended content:
+        .. default-domain:: cmake
+        .. cmake-module:: ../../src/modules/${module}.cmake")
+  endif()
+endforeach()

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -1,5 +1,5 @@
 ********************
-Notes for developers
+Notes for Developers
 ********************
 
 .. contents::
@@ -46,16 +46,36 @@ CMake
 
   * For project CMake code see the top-level ``CMakeLists.txt``. Bump this
     minimum required version if necessary.
-  * For installed modules add the following header (Adapt the version as
-    necessary):
+  * For installed modules see the next section.
 
-.. code-block:: cmake
+Adding a new, Simple Module
+===========================
 
-  if(CMAKE_VERSION VERSION_LESS 3.12)
-    message(FATAL_ERROR "Module FairFindPackage2 requires CMake 3.12 or later!")
-  endif()
+A simple module is a CMake module that can be used directly.
+Most modules are of this kind.
 
-  include_guard(GLOBAL)
+* Add it to ``src/modules/``, prefix it with ``Fair``.
+* Add the following header (Adapt the version as necessary):
+
+  .. code-block:: cmake
+
+    if(CMAKE_VERSION VERSION_LESS 3.12)
+      message(FATAL_ERROR "Module FairYourModule requires CMake 3.12 or later!")
+    endif()
+
+    include_guard(GLOBAL)
+
+* Add its name to the ``simple_modules`` list in the top ``CMakeLists.txt``.
+  This will automatically
+
+  * mark it for installation.
+  * add some basic tests for it.
+  * check for link in the documentation tree.
+
+* Add documentation link in ``docs/module/`` (see sibling files there).
+
+* Create specific tests in ``tests/FairYourModule/``.
+  See sibling directories to get some ideas.
 
 
 Changelog and Releases

--- a/docs/module/FairFormattedOutput.rst
+++ b/docs/module/FairFormattedOutput.rst
@@ -1,3 +1,2 @@
 .. default-domain:: cmake
 .. cmake-module:: ../../src/modules/FairFormattedOutput.cmake
-

--- a/docs/module/FairSummary.rst
+++ b/docs/module/FairSummary.rst
@@ -1,3 +1,2 @@
 .. default-domain:: cmake
 .. cmake-module:: ../../src/modules/FairSummary.cmake
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,11 +13,14 @@ configure_file(
   @ONLY
 )
 
+list(TRANSFORM simple_modules APPEND ".cmake"
+     OUTPUT_VARIABLE install_simple_modules)
+list(TRANSFORM install_simple_modules PREPEND "modules/")
+
 install(
   FILES
     ${CMAKE_CURRENT_BINARY_DIR}/modules/FairFindPackage2.cmake
-    modules/FairFormattedOutput.cmake
-    modules/FairSummary.cmake
+    ${install_simple_modules}
 
   DESTINATION "${PROJECT_INSTALL_MODULESDIR}"
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,5 +9,6 @@
 include(TestLib)
 
 add_module_tests(MODULE FairFindPackage2 PATH "${CMAKE_BINARY_DIR}/src/modules")
-add_module_tests(MODULE FairFormattedOutput)
-add_module_tests(MODULE FairSummary)
+foreach(module IN LISTS simple_modules)
+  add_module_tests(MODULE ${module})
+endforeach()


### PR DESCRIPTION
When adding a new module, one has to do many steps, and try not to forget one.

The common case are "simple modules". These modules can be used directly and do not need any special care. For those modules many steps can be automated.

Those steps, that can not be automated easily, are now documented in the "Notes for Developers".