### PR TITLE
feature: Set PROJECT_FairCMakeModules_VERSION on Import

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ New
   :command:`fair_generate_package_dependencies` generates appropriate
   entries.
 * Module :module:`FairProjectConfig`
+* The requested version of FairCMakeModules during
+  :command:`find_package` will show up in
+  :command:`fair_summary_package_dependencies`.
 
 
 **v0.2.0 (beta)** 2021-05-24

--- a/cmake/FairCMakeModulesConfig.cmake.in
+++ b/cmake/FairCMakeModulesConfig.cmake.in
@@ -12,4 +12,9 @@ set_and_check(@PROJECT_NAME@_PREFIX "@PACKAGE_CMAKE_INSTALL_PREFIX@")
 
 list(PREPEND CMAKE_MODULE_PATH "@PACKAGE_PROJECT_INSTALL_MODULESDIR@")
 
+# Record the requested version from find_package()
+if(@PROJECT_NAME@_FIND_VERSION)
+  set(_@PROJECT_NAME@_REQUESTED_VERSION "${@PROJECT_NAME@_FIND_VERSION}")
+endif()
+
 check_required_components(@PROJECT_NAME@)

--- a/src/modules/FairFindPackage2.cmake.in
+++ b/src/modules/FairFindPackage2.cmake.in
@@ -37,6 +37,10 @@ FairCMakeModules package.
 
 if(@PROJECT_NAME@_FOUND)
   list(APPEND PROJECT_PACKAGE_DEPENDENCIES @PROJECT_NAME@)
+  if(_@PROJECT_NAME@_REQUESTED_VERSION)
+    set(PROJECT_@PROJECT_NAME@_VERSION "${_@PROJECT_NAME@_REQUESTED_VERSION}")
+    unset(_@PROJECT_NAME@_REQUESTED_VERSION)
+  endif()
 endif()
 
 # private helper function to find longest common prefix in given

--- a/tests/project_mode_include/CMakeLists.txt
+++ b/tests/project_mode_include/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10...3.20)
 project(project_mode VERSION 1.2.3 LANGUAGES NONE)
 include(CMakePrintHelpers)
 
-find_package(FairCMakeModules 0.1 REQUIRED)
+find_package(FairCMakeModules 0.2 REQUIRED)
 cmake_print_variables(FairCMakeModules_FOUND)
 cmake_print_variables(FairCMakeModules_VERSION)
 cmake_print_variables(FairCMakeModules_PREFIX)
@@ -11,8 +11,12 @@ cmake_print_variables(MODULE)
 
 include(${MODULE})
 
-if(    MODULE STREQUAL FairFindPackage2
-   AND NOT FairCMakeModules IN_LIST PROJECT_PACKAGE_DEPENDENCIES)
-  message(FATAL_ERROR "FairCMakeModules missing from PROJECT_PACKAGE_DEPENDENCIES!")
+if(MODULE STREQUAL FairFindPackage2)
+  if(NOT FairCMakeModules IN_LIST PROJECT_PACKAGE_DEPENDENCIES)
+    message(FATAL_ERROR "FairCMakeModules missing from PROJECT_PACKAGE_DEPENDENCIES!")
+  endif()
+  if(NOT PROJECT_FairCMakeModules_VERSION STREQUAL 0.2)
+    message(FATAL_ERROR "PROJECT_FairCMakeModules_VERSION"
+            " (${PROJECT_FairCMakeModules_VERSION}) should be 0.2")
+  endif()
 endif()
-


### PR DESCRIPTION
Fixes: #17

When doing a
```cmake
find_package(FairCMakeModules 0.2 REQUIRED)
include(FairFindPackage2)
include(FairSummary)
fair_summary_package_dependencies()
```

it would be nice to list the requested version in the
summary table.  So record that information from
`find_package` so that it is shown finally in the summary.