### PR TITLE
feature: Upgrade to CMake 3.23

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,16 @@ jobs:
   main:
     strategy:
       matrix:
-        cmake: ['3.21', '3.20', '3.19', '3.18', '3.17', '3.16', '3.15']
+        cmake:
+        - '3.23'
+        - '3.22'
+        - '3.21'
+        - '3.20'
+        - '3.19'
+        - '3.18'
+        - '3.17'
+        - '3.16'
+        - '3.15'
         os: [ubuntu-latest]
         name: [Linux]
         include:
@@ -20,7 +29,7 @@ jobs:
     name: ${{ matrix.name }} - CMake ${{ matrix.cmake }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@v1.9
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ################################################################################
-#    Copyright (C) 2021 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH    #
+# Copyright (C) 2021-2022 GSI Helmholtzzentrum fuer Schwerionenforschung GmbH  #
 #                                                                              #
 #              This software is distributed under the terms of the             #
 #              GNU Lesser General Public Licence (LGPL) version 3,             #
@@ -7,7 +7,7 @@
 ################################################################################
 
 cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
-cmake_policy(VERSION 3.15...3.20)
+cmake_policy(VERSION 3.15...3.23)
 
 project(FairCMakeModules VERSION 1.0.0 LANGUAGES CXX
         HOMEPAGE_URL "https://github.com/FairRootGroup/FairCMakeModules")


### PR DESCRIPTION
No changes needed to support CMake 3.23.
So add to tests and upgrade policy.