### PR TITLE
fix(deps): Use even more less specific version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           -D STEPS=clean\;configure\;docs
           -S FairCMakeModules_test.cmake
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@v4.6
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: build/docs/html


### PR DESCRIPTION
Looks like `@4.6` does not work, because there is no tag. Being notified about breaking (major version) bumps seems fine as well.

Fixes:
- #39