### PR TITLE
ci: Include CMake 3.29 in Testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         cmake:
+        - '3.29'
         - '3.28'
         - '3.27'
         - '3.26'


### PR DESCRIPTION
At some point we probably should update some `cmake_policy` commands.

But testing that our 1.0.0 release still works with newer CMakes is already a good start.